### PR TITLE
default constructors for logarithmic numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 julia = "1.0"
-Requires = "0.5"
+Requires = ">=0.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -13,13 +13,13 @@ exp(::Type{ULogarithmic}, x::T) where {T<:Real} =
 	exp(ULogarithmic{T}, x)
 
 exp(::Type{Logarithmic{T}}, x::Real) where {T<:Real} =
-	Logarithmic{T}(exp(ULogarithmic{T}, x))
+	convert(Logarithmic{T}, exp(ULogarithmic{T}, x))
 
 exp(::Type{Logarithmic}, x::T) where {T<:Real} =
 	exp(Logarithmic{T}, x)
 
 exp(::Type{CLogarithmic{T}}, x::Union{Real,Complex}) where {T<:Real} =
-	CLogarithmic{T}(exp(ULogarithmic{T}, real(x)), imag(x))
+	CLogarithmic{T}(exp(ULogarithmic{T}, real(x)), T(imag(x)))
 
 exp(::Type{CLogarithmic}, x::T) where {T<:Real} =
 	exp(CLogarithmic{T}, x)
@@ -30,49 +30,3 @@ exp(::Type{CLogarithmic}, x::Complex{T}) where {T<:Real} =
 # convenience
 uexp(x) = exp(ULogarithmic, x)
 uexp(T,x) = exp(ULogarithmic{T}, x)
-
-# convert to ULogarithmic
-ULogarithmic{T}(x::Real) where {T<:Real} = exp(ULogarithmic{T}, log(x))
-
-ULogarithmic{T}(x::ULogarithmic{T}) where {T<:Real} = x
-
-ULogarithmic(x::Real) = exp(ULogarithmic, log(x))
-
-ULogarithmic(x::ULogarithmic) = x
-
-# convert to Logarithmic
-
-Logarithmic{T}(x::Real) where {T<:Real} =
-	Logarithmic{T}(ULogarithmic{T}(abs(x)), signbit(x))
-
-Logarithmic{T}(x::Logarithmic{T}) where {T<:Real} = x
-
-Logarithmic{T}(abs::ULogarithmic, signbit::Bool=false) where {T<:Real} =
-	Logarithmic{T}(ULogarithmic{T}(abs), signbit)
-
-Logarithmic(x::Real) =
-	Logarithmic(ULogarithmic(abs(x)), signbit(x))
-
-Logarithmic(abs::ULogarithmic{T}, signbit::Bool=false) where {T<:Real} =
-	Logarithmic{T}(abs, signbit)
-
-Logarithmic(x::Logarithmic) = x
-
-# convert to CLogarithmic
-
-CLogarithmic{T}(x::Union{Real,Complex}) where {T<:Real} =
-	CLogarithmic{T}(ULogarithmic{T}(abs(x)), convert(T, angle(x)))
-
-CLogarithmic{T}(x::CLogarithmic{T}) where {T<:Real} = x
-
-CLogarithmic{T}(x::CLogarithmic) where {T<:Real} =
-	CLogarithmic{T}(x.abs, x.angle)
-
-CLogarithmic{T}(abs::ULogarithmic, angle::Real=zero(T)) where {T<:Real} =
-	CLogarithmic{T}(ULogarithmic{T}(abs), convert(T, angle))
-
-CLogarithmic(x::Union{Real,Complex}) =
-	CLogarithmic(ULogarithmic(abs(x)), angle(x))
-
-CLogarithmic(abs::ULogarithmic{T}, angle::A=zero(T)) where {T<:Real, A<:Real} =
-	CLogarithmic{promote_type(T,A)}(abs, angle)

--- a/src/promotion.jl
+++ b/src/promotion.jl
@@ -32,10 +32,10 @@ promote_rule(::Type{A}, ::Type{R}) where {A<:AnyLog, R<:Real} =
 # generated for type-stability
 @generated promote_rule(::Type{CLogarithmic}, ::Type{C}) where {C<:Complex} =
 	try
-		:($(typeof(CLogarithmic(one(C)))))
+		:($(typeof(convert(CLogarithmic, one(C)))))
 	catch
 		:(Union{})
 	end
 
-promote_rule(::Type{CLogarithmic{T}}, ::Type{C}) where {T, C<:Complex} =
+promote_rule(::Type{CLogarithmic{T}}, ::Type{Complex{C}}) where {T, C<:Real} =
 	promote_type(CLogarithmic{T}, promote_type(CLogarithmic, C))

--- a/src/types.jl
+++ b/src/types.jl
@@ -9,9 +9,12 @@ Represents the positive real number `x` by storing its logarithm.
 """
 struct ULogarithmic{T} <: Real
   log::T
-  Base.exp(::Type{ULogarithmic{T}}, x::T) where {T<:Real} = new{T}(x)
 end
-
+Base.exp(::Type{ULogarithmic{T}}, x::T) where {T<:Real} = ULogarithmic{T}(x)
+Base.convert(::Type{ULogarithmic}, x::T2) where {T2<:ULogarithmic} = x
+Base.convert(::Type{ULogarithmic}, x::T2) where {T2<:Real} = convert(ULogarithmic{T2}, x)
+Base.convert(::Type{ULogarithmic{T1}}, x::T2) where {T1<:Real, T2<:ULogarithmic} = ULogarithmic{T1}(T1(x.log))
+Base.convert(::Type{ULogarithmic{T1}}, x::T2) where {T1<:Real, T2<:Real} = exp(ULogarithmic{T1}, log(x))
 
 """
     Logarithmic(x)
@@ -24,8 +27,12 @@ Represents the real number `x` by storing its absolute value as a [`ULogarithmic
 struct Logarithmic{T} <: Real
   abs::ULogarithmic{T}
   signbit::Bool
-  Logarithmic{T}(abs::ULogarithmic{T}, signbit::Bool=false) where {T<:Real} = new{T}(abs, signbit)
 end
+
+Base.convert(::Type{Logarithmic}, x::T2) where T2<:Number = convert(Logarithmic{T2}, x)
+Base.convert(::Type{Logarithmic{T1}}, x::T2) where {T1<:Real, T2<:Logarithmic} = Logarithmic{T1}(convert(ULogarithmic{T1}, x.abs), x.signbit)
+Base.convert(::Type{Logarithmic{T1}}, x::T2) where {T1<:Real, T2<:ULogarithmic} = Logarithmic{T1}(convert(ULogarithmic{T1}, x), false)
+Base.convert(::Type{Logarithmic{T1}}, x::T2) where {T1<:Real, T2<:Real} = Logarithmic(convert(ULogarithmic{T1}, abs(x)), signbit(x))
 
 """
     CLogarithmic(x)
@@ -38,9 +45,15 @@ Represents the complex number `x` by storing its absolute value as a [`ULogarith
 struct CLogarithmic{T} <: Number
   abs :: ULogarithmic{T}
   angle :: T
-  CLogarithmic{T}(abs::ULogarithmic{T}, angle::T=zero(T)) where {T<:Real} = new{T}(abs, angle)
 end
 
 # for convenience
 const AnyLog{T} = Union{ULogarithmic{T}, Logarithmic{T}, CLogarithmic{T}}
 const RealLog{T} = Union{ULogarithmic{T}, Logarithmic{T}}
+
+Base.convert(::Type{CLogarithmic}, x::T2) where T2<:Real = convert(CLogarithmic{T2}, x)
+Base.convert(::Type{CLogarithmic}, x::Complex{T2}) where T2<:Number = convert(CLogarithmic{T2}, x)
+Base.convert(::Type{CLogarithmic{T1}}, x::T2) where {T1<:Real, T2<:CLogarithmic} = CLogarithmic{T1}(convert(ULogarithmic{T1}, x.abs), x.angle)
+Base.convert(::Type{CLogarithmic{T1}}, x::T2) where {T1<:Real, T2<:Logarithmic} = CLogarithmic{T1}(convert(ULogarithmic{T1}, x.abs), x.signbit ? zero(T1) : convert(T1, π))
+Base.convert(::Type{CLogarithmic{T1}}, x::T2) where {T1<:Real, T2<:ULogarithmic} = CLogarithmic{T1}(convert(ULogarithmic{T1}, x), zero(T1))
+Base.convert(::Type{CLogarithmic{T1}}, x::T2) where {T1<:Real, T2<:Number} = CLogarithmic(convert(ULogarithmic{T1}, abs(x)), angle(x))


### PR DESCRIPTION
This would fix #3 

* Constructors now do not compute the logarithm anymore.
* One can use `convert(T, x)` instead.

Note:
It might break packages that depend on `LogarithmicNumbers.jl`.