### PR TITLE
ForwardDiff support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LogarithmicNumbersForwardDiffExt = "ForwardDiff"
 
 [compat]
+ForwardDiff = "0.10"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,19 @@ version = "1.2.1"
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[weakdeps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+
+[extensions]
+LogarithmicNumbersForwardDiffExt = "ForwardDiff"
+
 [compat]
 julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test"]
+test = ["Aqua", "ForwardDiff", "Test"]

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ possibilities for `func`:
 
 ## Autodiff
 
-If you load [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl), you should be able to compute
+On Julia >= 1.9, if you load [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl), you should be allowed to compute
 
 - derivatives of functions involving `exp(Logarithmic, x)`
 - derivatives of functions evaluated at `Logarithmic(x)`

--- a/README.md
+++ b/README.md
@@ -83,3 +83,12 @@ possibilities for `func`:
   `pdf`, `cdf`, `ccdf`.
 - [SpecialFunctions.jl](https://github.com/JuliaMath/SpecialFunctions.jl):
   `gamma`, `factorial`, `beta`, `erfc`, `erfcx`.
+
+## Autodiff
+
+If you load [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl), you should be able to compute
+
+- derivatives of functions involving `exp(Logarithmic, x)`
+- derivatives of functions evaluated at `Logarithmic(x)`
+
+This functionality is experimental, please report any bug or unexpected behavior.

--- a/ext/LogarithmicNumbersForwardDiffExt.jl
+++ b/ext/LogarithmicNumbersForwardDiffExt.jl
@@ -1,0 +1,44 @@
+module LogarithmicNumbersForwardDiffExt
+
+using ForwardDiff: ForwardDiff, Dual, partials
+using LogarithmicNumbers: LogarithmicNumbers, AnyLogarithmic, Logarithmic, ULogarithmic
+
+## Promotion rules
+
+function Base.promote_rule(::Type{Logarithmic{R}}, ::Type{Dual{T,V,N}}) where {R<:Real,T,V,N}
+    return Dual{T,promote_rule(Logarithmic{R}, V),N}
+end
+
+function Base.promote_rule(::Type{ULogarithmic{R}}, ::Type{Dual{T,V,N}}) where {R<:Real,T,V,N}
+    return Dual{T,promote_rule(ULogarithmic{R}, V),N}
+end
+
+## Constructors
+
+# Based on the unary_definition macro in ForwardDiff.jl (https://github.com/JuliaDiff/ForwardDiff.jl/blob/6a6443b754b0fcfb4d671c9a3d01776df801f498/src/dual.jl#L230-L244)
+
+function Base.exp(::Type{ULogarithmic{R}}, d::Dual{T,V,N}) where {R<:Real,T,V,N}
+    x = ForwardDiff.value(d)
+    val = exp(ULogarithmic{R}, x)
+    deriv = exp(ULogarithmic{R}, x)
+    return ForwardDiff.dual_definition_retval(Val{T}(), val, deriv, partials(d))
+end
+
+function Base.exp(::Type{Logarithmic{R}}, d::Dual{T,V,N}) where {R<:Real,T,V,N}
+    x = ForwardDiff.value(d)
+    val = exp(Logarithmic{R}, x)
+    deriv = exp(Logarithmic{R}, x)
+    return ForwardDiff.dual_definition_retval(Val{T}(), val, deriv, partials(d))
+end
+
+function Base.exp(::Type{ULogarithmic}, d::Dual{T,V,N}) where {T,V,N}
+    return exp(ULogarithmic{V}, d)
+end
+
+function Base.exp(::Type{Logarithmic}, d::Dual{T,V,N}) where {T,V,N}
+    return exp(Logarithmic{V}, d)
+end
+
+# TODO: do we need more constructors?
+
+end

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -2,15 +2,19 @@ using ForwardDiff: derivative, gradient
 using LogarithmicNumbers
 using Test
 
-f(x) = exp(x + 1)
-g1(x) = exp(Logarithmic, x + 1)
-g2(x) = exp(LogFloat64, x + 1)
-h1(x) = exp(ULogarithmic, x + 1)
-h2(x) = exp(ULogFloat64, x + 1)
+f(x) = log(exp(x) * x)
+g1(x) = log(exp(ULogarithmic, x) * x)
+g2(x) = log(exp(ULogFloat64, x) * x)
+h1(x) = log(exp(Logarithmic, x) * x)
+h2(x) = log(exp(LogFloat64, x) * x)
 
-@test log(derivative(f, LogFloat64(1000.0))) ≈ log(exp(Logarithmic, 1001.0))
-@test log(derivative(f, ULogFloat64(1000.0))) ≈ log(exp(Logarithmic, 1001.0))
-@test derivative(g1, 1000.0) ≈ exp(Logarithmic, 1001.0)
-@test derivative(g2, 1000.0) ≈ exp(Logarithmic, 1001.0)
-@test derivative(h1, 1000.0) ≈ exp(ULogarithmic, 1001.0)
-@test derivative(h2, 1000.0) ≈ exp(ULogarithmic, 1001.0)
+x = 1000
+logder = log(1 + inv(x)) 
+
+@test isnan(log(derivative(f, x)))
+@test log(derivative(f, LogFloat64(x))) ≈ logder
+@test log(derivative(f, ULogFloat64(x))) ≈ logder
+@test log(derivative(g1, x)) ≈ logder
+@test log(derivative(g2, x)) ≈ logder
+@test log(derivative(h1, x)) ≈ logder
+@test log(derivative(h2, x)) ≈ logder

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -9,12 +9,12 @@ h1(x) = log(exp(Logarithmic, x) * x)
 h2(x) = log(exp(LogFloat64, x) * x)
 
 x = 1000
-logder = log(1 + inv(x)) 
+d = 1 + inv(x)
 
-@test isnan(log(derivative(f, x)))
-@test log(derivative(f, LogFloat64(x))) ≈ logder
-@test log(derivative(f, ULogFloat64(x))) ≈ logder
-@test log(derivative(g1, x)) ≈ logder
-@test log(derivative(g2, x)) ≈ logder
-@test log(derivative(h1, x)) ≈ logder
-@test log(derivative(h2, x)) ≈ logder
+@test isnan(derivative(f, x))
+@test derivative(f, LogFloat64(x)) ≈ d
+@test derivative(f, ULogFloat64(x)) ≈ d
+@test derivative(g1, x) ≈ d
+@test derivative(g2, x) ≈ d
+@test derivative(h1, x) ≈ d
+@test derivative(h2, x) ≈ d

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -1,0 +1,16 @@
+using ForwardDiff: derivative, gradient
+using LogarithmicNumbers
+using Test
+
+f(x) = exp(x + 1)
+g1(x) = exp(Logarithmic, x + 1)
+g2(x) = exp(LogFloat64, x + 1)
+h1(x) = exp(ULogarithmic, x + 1)
+h2(x) = exp(ULogFloat64, x + 1)
+
+@test log(derivative(f, LogFloat64(1000.0))) ≈ log(exp(Logarithmic, 1001.0))
+@test log(derivative(f, ULogFloat64(1000.0))) ≈ log(exp(Logarithmic, 1001.0))
+@test derivative(g1, 1000.0) ≈ exp(Logarithmic, 1001.0)
+@test derivative(g2, 1000.0) ≈ exp(Logarithmic, 1001.0)
+@test derivative(h1, 1000.0) ≈ exp(ULogarithmic, 1001.0)
+@test derivative(h2, 1000.0) ≈ exp(ULogarithmic, 1001.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,5 @@
 using LogarithmicNumbers, Test, Aqua
 
-Aqua.test_all(LogarithmicNumbers)
-
 function _approx(x,y)
     ans = isapprox(x, y, atol=1e-3) || (isnan(x) && isnan(y))
     ans || @show x y
@@ -37,7 +35,11 @@ Int[x for x in vals if x isa Int && x ≥ 0],
 atypes = (ULogarithmic, Logarithmic)
 atypes2 = (ULogarithmic, ULogFloat32, Logarithmic, LogFloat32)
 
-@testset "LogarithmicNumbers" begin
+@testset verbose=true "LogarithmicNumbers" begin
+
+    @testset "Aqua" begin
+        Aqua.test_all(LogarithmicNumbers, project_toml_formatting=VERSION>v"1.6")
+    end
 
     @testset "types" begin
         @test @isdefined ULogarithmic

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -570,6 +570,8 @@ atypes2 = (ULogarithmic, ULogFloat32, Logarithmic, LogFloat32)
     end
 
     @testset "ForwardDiff" begin
-        include("forwarddiff.jl")
+        if VERSION >= v"1.9"
+            include("forwarddiff.jl")
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,8 +37,8 @@ atypes2 = (ULogarithmic, ULogFloat32, Logarithmic, LogFloat32)
 
 @testset verbose=true "LogarithmicNumbers" begin
 
-    @testset "Aqua" begin
-        Aqua.test_all(LogarithmicNumbers, project_toml_formatting=VERSION>v"1.6")
+    @testset verbose=true "Aqua" begin
+        Aqua.test_all(LogarithmicNumbers, project_toml_formatting=(VERSION >= v"1.7"))
     end
 
     @testset "types" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -569,4 +569,7 @@ atypes2 = (ULogarithmic, ULogFloat32, Logarithmic, LogFloat32)
 
     end
 
+    @testset "ForwardDiff" begin
+        include("forwarddiff.jl")
+    end
 end


### PR DESCRIPTION
Fix #13 by ensuring compatibility with `Dual` numbers in a package extension.

For now, method overloads only include:
- promotion rules
- `exp` constructors

This supersedes the WIP package https://github.com/gdalle/ForwardDiffOverLogarithmicNumbers.jl

Ping @cjdoris for review, and @longemen3000 who suggested making this an extension in https://github.com/gdalle/ForwardDiffOverLogarithmicNumbers.jl/pull/1