### PR TITLE
ForwardDiff compat

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,24 +18,15 @@ jobs:
         os: [ubuntu-latest]
         jlversion: ['1','1.6']
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.jlversion }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ LogarithmicNumbersForwardDiffExt = "ForwardDiff"
 
 [compat]
 Aqua = "0.8"
-ForwardDiff = "0.10"
+ForwardDiff = "0.10, 1"
 Random = "1"
 Test = "1"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogarithmicNumbers"
 uuid = "aa2f6b4e-9042-5d33-9679-40d3a6b85899"
 authors = ["Christopher Doris"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,10 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LogarithmicNumbersForwardDiffExt = "ForwardDiff"
 
 [compat]
-Aqua = "0.8"
+Aqua = "0 - 999"
 ForwardDiff = "0.10, 1"
 Random = "1"
-Test = "1"
+Test = "0 - 999"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
This updates the `ForwardDiff` compat. Without this, upgrading `ForwardDiff` to >= 1 will downgrade `LogarithmicNumbers` to v1.2.1. The main breaking change in `ForwardDiff` 1 is to do with equality of `Dual` numbers, which seems to not be relevant here.